### PR TITLE
chat-spaceの自動更新

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,8 @@
 $(function(){
 
+
   function buildHTML(message){
-    var image = message.image ? `<img src= ${ message.image }>` : "";
+    var image = message.image ? `<img class= "lower-message__image" src=${message.image} >` : "";
     var html =
       `<div class="message" data-message-id=${message.id}>
         <div class="upper-message">
@@ -22,10 +23,12 @@ $(function(){
     return html;
   }
 
+
   $('.new_message').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
     var url = $(this).attr('action')
+    
     $.ajax({
       url: url,
       type: "POST",
@@ -46,4 +49,33 @@ $(function(){
     return false;
   });
   
+
+  var reloadMessages = function() {
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){
+      last_message_id = $('.message:last').data("message-id");
+      console.log(location.href)
+      $.ajax({
+      url: 'api/messages',
+      type: 'get',
+      data: {id: last_message_id},
+      dataType: 'json',
+      processData: false,
+      contentType: false
+      })
+      .done(function(messages) {
+        var insertHTML = '';
+        messages.forEach(function (message) {
+          insertHTML = buildHTML(message); 
+          $('.messages').append(insertHTML);
+        })
+        $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 1);  
+      })
+      .fail(function() {
+        console.log('error');
+      });
+    }
+  };
+
+  setInterval(reloadMessages, 7000);
+
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -53,7 +53,6 @@ $(function(){
   var reloadMessages = function() {
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
       last_message_id = $('.message:last').data("message-id");
-      console.log(location.href)
       $.ajax({
       url: 'api/messages',
       type: 'get',
@@ -71,7 +70,7 @@ $(function(){
         $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 1);  
       })
       .fail(function() {
-        console.log('error');
+        alert('error');
       });
     }
   };

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.id message.id
+  json.text message.text
+  json.image message.image_url
+  json.date message.created_at.strftime("%Y年%m月%d日 %H時%M分 タイムゾーン:%Z")
+  json.user_name message.user.name
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{"data-message-id": "#{message.id}"}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
Lesson10
chat-spaceの自動更新機能

メッセージ画面を自動的に更新する。
これにより、自分以外のユーザーが送信したメッセージも自動で追加表示できる。

メッセージの画面以外では自動更新は行われない。（グループ作成や編集のページなど）

自動更新は7秒毎に更新されます。
また、最新のメッセージ（メッセージ最下部）に自動で移動するようにしています。
今回、１ミリ秒でメッセージ最下部に行くようになっているので
人間ではスクロールしているのが判断できない感じになっているのご了承ください。
fastの速度ですと7秒毎にスクロールするのが少しうっとおしかったので・・・

# Why
二人以上でチャットをする上でページをリロードしないと相手のメッセージが
わからないのは不便なため、機械側で更新してあげて、不便さを解消する。